### PR TITLE
Implement "active" events

### DIFF
--- a/meeting_server/api/events/models.py
+++ b/meeting_server/api/events/models.py
@@ -1,12 +1,12 @@
+from datetime import datetime, timedelta
+from enum import Enum
+
 from django.db import models
-from api.users.models import UserProfile
+
 from api.locations.models import Location
-from rest_framework.fields import ListField
+from api.users.models import UserProfile
 
-import datetime
-
-today = datetime.datetime.today().strftime('%Y-%m-%d')
-rinnow = datetime.datetime.today().strftime('%H:%M')
+start_buffer = timedelta(hours=2)
 
 
 class Event(models.Model):
@@ -21,3 +21,57 @@ class Event(models.Model):
 
     def __unicode__(self):
         return u"file_upload {0}".format(self.file_attachment.url)
+
+    class OverallState(Enum):
+        NOT_STARTED = 0
+        STARTING = 1
+        ONGOING = 2
+        ENDING = 3
+        OVER = 4
+
+    def current_overall_state(self) -> OverallState:
+        """
+        :return: The current overall state of the event based on the current wall-clock time and the individual states
+        of all attendees
+        """
+        from api.invitations.models import Invitation
+        now = datetime.now()
+        start = datetime.combine(self.event_date, self.event_time)
+        duration = timedelta(
+            hours=self.event_duration.hour,
+            minutes=self.event_duration.minute,
+            seconds=self.event_duration.second,
+            microseconds=self.event_duration.microsecond,
+        )
+        if now < start - start_buffer:
+            return Event.OverallState.NOT_STARTED
+        attendees = UserProfile.objects.filter(invitation__event_id=self, invitation__status=Invitation.ACCEPTED)
+        if now < start + duration:
+            if any((not hasattr(u, 'activeevent') or u.activeevent.state == ActiveEvent.GOING_TO for u in attendees)):
+                return Event.OverallState.STARTING
+            else:
+                return Event.OverallState.ONGOING
+        else:
+            if any((hasattr(u, 'activeevent') for u in attendees)):
+                return Event.OverallState.ENDING
+            else:
+                return Event.OverallState.OVER
+
+
+class ActiveEvent(models.Model):
+    """
+    Maintains what a user's current state is for an "active" event.
+    Note that a user can only be "active" in one event at a time.
+    """
+    GOING_TO = 1
+    CURRENTLY_AT = 2
+    LEAVING_FROM = 3
+    ACTIVE_EVENT_STATE_CHOICES = (
+        (GOING_TO, "Going To"),
+        (CURRENTLY_AT, "Currently At"),
+        (LEAVING_FROM, "Leaving From"),
+    )
+
+    event = models.ForeignKey(Event, on_delete=models.CASCADE)
+    user = models.OneToOneField(UserProfile, on_delete=models.CASCADE)
+    state = models.PositiveSmallIntegerField(choices=ACTIVE_EVENT_STATE_CHOICES)

--- a/meeting_server/api/events/serializers.py
+++ b/meeting_server/api/events/serializers.py
@@ -4,7 +4,7 @@ from typing import Any
 from django.db.models import Model
 from django.http import Http404
 
-from .models import Event
+from .models import Event, ActiveEvent
 from rest_framework.response import Response
 
 from rest_framework import status
@@ -36,6 +36,7 @@ class EventModelSerializer(serializers.ModelSerializer):
         response = super().to_representation(instance)
         response['event_location'] = LocationModelSerializer(instance.event_location).data
         # response['event_admin'] = UserProfileSerializer(instance.event_admin).data
+        response['current_overall_state'] = instance.current_overall_state().value
         return response
 
     # def to_representation(self, instance):
@@ -105,6 +106,12 @@ class EventPermissionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Event
         fields = ('pk', 'event_admin')  # FIXME: probably broken
+
+
+class ActiveEventSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ActiveEvent
+        fields = ('event', 'state')
 
 
 # only for use with IcalRenderer

--- a/meeting_server/api/events/tests.py
+++ b/meeting_server/api/events/tests.py
@@ -1,1 +1,72 @@
+import datetime
+import json
+
+import django.contrib.auth.models as auth_models
+from django.test import TestCase
+from rest_auth.app_settings import create_token
+from rest_auth.models import TokenModel
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from api.invitations.models import Invitation
+from api.locations.models import Location
+from api.users.models import UserProfile
+from .models import Event, ActiveEvent
+
+
 # Create your tests here.
+
+class ActiveEventLeavingTests(TestCase):
+    def setUp(self):
+        super(ActiveEventLeavingTests, self).setUp()
+        self.alice = UserProfile.objects.create(django_user=auth_models.User.objects.create(
+            username='alice', first_name='Alice', last_name='Q.', email='alice@example.com'))
+        self.bob = UserProfile.objects.create(django_user=auth_models.User.objects.create(
+            username='bob', first_name='Bob', last_name='Q.', email='bob@example.com'))
+        self.charlie = UserProfile.objects.create(django_user=auth_models.User.objects.create(
+            username='charlie', first_name='Charlie', last_name='Q.', email='charlie@example.com'))
+
+        self.party_place = Location.objects.create(street_address='123 Main St.', city='Anywhere', state='IN')
+        start = datetime.datetime.now() - datetime.timedelta(hours=1)
+        self.alice_party = Event.objects.create(
+            event_admin=self.alice,
+            event_name='Party!',
+            event_date=start.date(),
+            event_time=start.time(),
+            event_duration=datetime.time(0, 50),
+            event_location=self.party_place,
+            notes='PREPARE TO PARTY',
+        )
+        Invitation.objects.create(user_id=self.bob, event_id=self.alice_party, status=Invitation.ACCEPTED)
+        Invitation.objects.create(user_id=self.charlie, event_id=self.alice_party, status=Invitation.ACCEPTED)
+        ActiveEvent.objects.create(event=self.alice_party, user=self.bob, state=ActiveEvent.LEAVING_FROM)
+        ActiveEvent.objects.create(event=self.alice_party, user=self.charlie, state=ActiveEvent.LEAVING_FROM)
+
+        self.client = APIClient()
+
+    def test_leave_one(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Token ' + create_token(TokenModel, self.bob.django_user, None).key)
+        response = self.client.delete('/events/current-user-active-event')
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        response = self.client.get(f'/events/{self.alice_party.id}')
+        assert response.status_code == status.HTTP_200_OK
+
+        assert json.loads(response.content)['current_overall_state'] == Event.OverallState.ENDING.value
+
+    def test_leave_all(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Token ' + create_token(TokenModel, self.bob.django_user, None).key)
+        response = self.client.delete('/events/current-user-active-event')
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Token ' + create_token(TokenModel, self.charlie.django_user, None).key)
+        response = self.client.delete('/events/current-user-active-event')
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        response = self.client.get(f'/events/{self.alice_party.id}')
+        assert response.status_code == status.HTTP_200_OK
+
+        assert json.loads(response.content)['current_overall_state'] == Event.OverallState.OVER.value

--- a/meeting_server/api/events/urls.py
+++ b/meeting_server/api/events/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
+    url(r'^current-user-active-event$', views.EventActive.as_view(), name='api-event-active'),
     url(r'new_event$', views.EventCreateView.as_view(), name='api-event-create'),
     url(r'^ical/(?P<ical_key>[0-9a-zA-Z]{24}).ical$', views.IcalView.as_view(), name='api-event-ical'),
     url(r'(?P<pk>.+)$', views.EventDetailView.as_view(), name='api-event-detail'),

--- a/meeting_server/api/events/views.py
+++ b/meeting_server/api/events/views.py
@@ -1,14 +1,16 @@
 from django.http import Http404
 from django.core.exceptions import ObjectDoesNotExist
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework import generics as drf_generics
 
+from api import fcm
 from api.events.renderers import IcalRenderer
-from .models import Event
-from .serializers import EventModelSerializer, EventCreateSerializer, EventListQuerySerializer, EventIcalSerializer
+from .models import Event, ActiveEvent
+from .serializers import EventModelSerializer, EventCreateSerializer, EventListQuerySerializer, EventIcalSerializer, \
+    ActiveEventSerializer
 from rest_framework.parsers import MultiPartParser, FormParser, FileUploadParser
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
@@ -86,11 +88,39 @@ class EventDetailView(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
+class EventActive(drf_generics.RetrieveUpdateDestroyAPIView):
+    """
+    Retrieve or update the current user's state for an event.
+    1: going to event
+    2: currently at event
+    3: leaving from event
+    (null): not yet going to event/already arrived home from event
+    """
+
+    serializer_class = ActiveEventSerializer
+    permission_classes = (IsAuthenticated,)
+
+    def get_object(self) -> ActiveEvent:
+        u = self.request.user.userprofile
+        if hasattr(u, 'activeevent'):
+            return u.activeevent
+        else:
+            # kinda jank but works well enough
+            return ActiveEvent()
+
+    def get_queryset(self):
+        return ActiveEvent.objects.none()
+
+    def perform_destroy(self, instance: ActiveEvent):
+        fcm.notify_arrived_home(instance.event, instance.user)
+        super().perform_destroy(instance)
+
+
 class IcalView(drf_generics.ListAPIView):
     serializer_class = EventIcalSerializer
     pagination_class = None
     renderer_classes = (IcalRenderer,)
-    permission_classes = ()
+    permission_classes = (AllowAny,)
 
     def get_queryset(self):
         return Event.objects.filter(invitation__user_id__ical_key=self.kwargs['ical_key'])

--- a/meeting_server/api/fcm.py
+++ b/meeting_server/api/fcm.py
@@ -19,37 +19,48 @@ try:
     firebase_enabled = True
 except FileNotFoundError:
     logger.warning("Firebase key not found; notifications won't work")
-    pass
 
 
-def notify_invite(user: UserProfile, event: Event, dry_run=False):
-    if not firebase_enabled:
-        return
+def _do_message(data: dict, user: UserProfile, dry_run: bool):
     if user.firebase_reg_token != "":
-        data = {
-            'kind': 'invite',
-            'event_id': str(event.pk),
-            'event_name': event.event_name,
-        }
         logger.debug(f'sending fcm message to {user.django_user.username} (id {user.django_user_id}): {data}')
         messaging.send(messaging.Message(
             data=data,
             token=user.firebase_reg_token
         ), dry_run=dry_run)
+    else:
+        logger.info(f'{user.django_user.username} (id {user.django_user_id}) has no firebase registration token')
+
+
+def notify_invite(user: UserProfile, event: Event, dry_run=False):
+    if not firebase_enabled:
+        return
+    data = {
+        'kind': 'invite',
+        'event_id': str(event.pk),
+        'event_name': event.event_name,
+    }
+    _do_message(data, user, dry_run)
 
 
 def notify_edit(event: Event, dry_run=False):
     if not firebase_enabled:
         return
     for user in UserProfile.objects.filter(invitation__event_id=event, invitation__status=Invitation.ACCEPTED):
-        if user.firebase_reg_token != "":
-            data = {
-                'kind': 'edit',
-                'event_id': str(event.pk),
-                'event_name': event.event_name,
-            }
-            logger.debug(f'sending fcm message to {user.django_user.username} (id {user.django_user_id}): {data}')
-            messaging.send(messaging.Message(
-                data=data,
-                token=user.firebase_reg_token
-            ), dry_run=dry_run)
+        data = {
+            'kind': 'edit',
+            'event_id': str(event.pk),
+            'event_name': event.event_name,
+        }
+        _do_message(data, user, dry_run)
+
+
+def notify_arrived_home(event: Event, obj_user: UserProfile, dry_run=False):
+    if not firebase_enabled:
+        return
+    for user in UserProfile.objects.filter(invitation__event_id=event, invitation__status=Invitation.ACCEPTED):
+        data = {
+            'kind': 'arrived_home',
+            'user_full_name': obj_user.django_user.get_full_name()
+        }
+        _do_message(data, user, dry_run)

--- a/meeting_server/api/test_fcm.py
+++ b/meeting_server/api/test_fcm.py
@@ -55,3 +55,13 @@ class FcmTests(TestCase):
         self.charlie.firebase_reg_token = ''
         self.charlie.save()
         fcm.notify_edit(self.alice_party, dry_run=True)
+
+    def test_notif_arrived_home(self):
+        self.bob.firebase_reg_token = _TEST_DEVICE_TOKEN
+        self.bob.save()
+        fcm.notify_arrived_home(self.alice_party, self.alice, dry_run=True)
+
+    def test_notif_arrived_home_notoken(self):
+        self.charlie.firebase_reg_token = ''
+        self.charlie.save()
+        fcm.notify_arrived_home(self.alice_party, self.alice, dry_run=True)


### PR DESCRIPTION
Each user can be "active" in up to one event at a time.
`GET /events/current-user-active-event` to see what the current user's current state is. Use `PUT` or `DELETE` to set what the current user is doing.
https://github.com/HMPerson1/meeting-master/blob/8109a8e97870f765bd7bfdcc15356f8317bdbd0e/meeting_server/api/events/models.py#L67-L69
- start going to event: put state=1
- arrive at event: put state=2
- leave event: put state=3
  (note: the server can't do this automatically when the event ends; we might want the client to do this automatically at the right time, or we can treat state=2 on an ending event as eqivalent to 3)
- arrive home: delete

Events can determine "overall" state based on the current wall-clock time and the individual states of all attendees
https://github.com/HMPerson1/meeting-master/blob/8109a8e97870f765bd7bfdcc15356f8317bdbd0e/meeting_server/api/events/models.py#L26-L31
- 0 to 1: when wall-clock hits 2 hours before `event_start`
- 1 to 2: when all attendees have arrived (attendees being users who have accepted an invite)
- 2 to 3: when wall-clock hits `event_start` + `event_duration`
- 3 to 4: when all attendees have arrived home

(note: an event can go directly from 1 to 4 if no one arrives up before it's over)